### PR TITLE
Avoid duplicate click handling on touch devices

### DIFF
--- a/src/web-view/HexaWordGame.ts
+++ b/src/web-view/HexaWordGame.ts
@@ -249,15 +249,19 @@ export class HexaWordGame {
   private setupEventHandlers(): void {
     // Handle resize
     window.addEventListener('resize', () => this.handleResize());
-    
-    // Handle canvas clicks (for future interaction)
-    this.canvas.addEventListener('click', (e) => this.handleClick(e));
-    
+
+    const isMobile = this.isMobileDevice();
+
+    // Handle canvas clicks (desktop interactions)
+    if (!isMobile) {
+      this.canvas.addEventListener('click', (e) => this.handleClick(e));
+    }
+
     // Handle touch events for mobile
-    this.canvas.addEventListener('touchstart', (e) => this.handleTouch(e));
-    
+    this.canvas.addEventListener('touchstart', (e) => this.handleTouch(e), { passive: false });
+
     // Handle keyboard input (only on desktop/laptop)
-    if (!this.isMobileDevice()) {
+    if (!isMobile) {
       this.setupKeyboardHandling();
     }
   }


### PR DESCRIPTION
## Summary
- avoid attaching desktop click handlers on mobile/touch devices to prevent duplicate interactions
- ensure touchstart listener remains active with non-passive option while preserving desktop keyboard handling

## Testing
- npm test *(fails: existing determinism, word placement, and game state expectations unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_b_68cfb7a9cd708327988954318ab4cef4