### PR TITLE
Fix mobile touch input and highlight used cells

### DIFF
--- a/src/web-view/components/InputHexGrid.ts
+++ b/src/web-view/components/InputHexGrid.ts
@@ -497,12 +497,19 @@ export class InputHexGrid {
             // Used letters have very subtle dark fill
             this.ctx.fillStyle = 'rgba(0, 0, 0, 0.15)';
             this.ctx.fill();
-            
+
             // Subtle stroke
             this.ctx.strokeStyle = this.currentColors?.inputCellStroke || 'rgba(255, 255, 255, 0.04)';
             this.ctx.lineWidth = 1;
             this.ctx.stroke();
-            
+
+            // Prominent red outline to indicate used cells
+            this.ctx.save();
+            this.ctx.strokeStyle = 'rgba(255, 64, 64, 0.85)';
+            this.ctx.lineWidth = 2;
+            this.ctx.stroke();
+            this.ctx.restore();
+
           } else {
             // Normal input cells - darker fill
             this.ctx.fillStyle = this.currentColors?.inputCellFill || 'rgba(0, 0, 0, 0.2)';


### PR DESCRIPTION
## Summary
- suppress synthetic mouse clicks that follow touch interactions so repeated taps can deselect letters on mobile
- extend touch handling to guard against missing touch points when the event fires
- render a red outline around already-used input hexes for clearer feedback

## Testing
- npm test *(fails: existing determinism, placement, and game state expectations in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68cfc1a0e0d483278fe7d02d215e50ef