### PR TITLE
Adjust booster buttons position

### DIFF
--- a/src/client/components/GameUI.ts
+++ b/src/client/components/GameUI.ts
@@ -149,7 +149,7 @@ export class GameUI {
     const btn = document.createElement('button');
     btn.id = 'hw-reveal-btn';
     btn.className = 'fixed left-2 w-10 h-10 rounded-full text-hw-text-primary backdrop-blur-md border transition-all duration-base flex items-center justify-center pointer-events-auto z-50';
-    btn.style.cssText = 'bottom: 180px; background: rgba(42, 52, 70, 0.8); border-color: rgba(59, 71, 96, 0.3); position: fixed;';
+    btn.style.cssText = 'bottom: 220px; background: rgba(42, 52, 70, 0.8); border-color: rgba(59, 71, 96, 0.3); position: fixed;';
     
     // Container for icon and badge
     btn.innerHTML = `
@@ -177,7 +177,7 @@ export class GameUI {
     const btn = document.createElement('button');
     btn.id = 'hw-target-btn';
     btn.className = 'fixed right-2 w-10 h-10 rounded-full text-hw-text-primary backdrop-blur-md border transition-all duration-base flex items-center justify-center pointer-events-auto z-50';
-    btn.style.cssText = 'bottom: 180px; background: rgba(42, 52, 70, 0.8); border-color: rgba(59, 71, 96, 0.3); position: fixed;';
+    btn.style.cssText = 'bottom: 220px; background: rgba(42, 52, 70, 0.8); border-color: rgba(59, 71, 96, 0.3); position: fixed;';
     
     // Container for icon and badge
     btn.innerHTML = `


### PR DESCRIPTION
## Summary
- raise the reveal and target booster buttons higher on the screen so they sit further above the input cells

## Testing
- npm test *(fails: existing vitest suites currently contain failing assertions in determinism, word placement, and game state tests)*

------
https://chatgpt.com/codex/tasks/task_b_68cfc88927fc83279ec116fb375b2447