### PR TITLE
Add in-game level explorer access and show anonymous levels

### DIFF
--- a/src/client/components/GameUI.ts
+++ b/src/client/components/GameUI.ts
@@ -11,6 +11,7 @@ export class GameUI {
   private coinEl: HTMLElement;
   private settingsBtn: HTMLButtonElement;
   private menuPanel: HTMLElement;
+  private exploreBtn: HTMLButtonElement;
   private shuffleBtn: HTMLButtonElement;
   private revealBtn: HTMLButtonElement;
   private targetBtn: HTMLButtonElement;
@@ -23,6 +24,7 @@ export class GameUI {
     this.coinEl = this.createCoinDisplay();
     this.settingsBtn = this.createSettingsButton();
     this.menuPanel = this.createMenuPanel();
+    this.exploreBtn = this.createExploreButton();
     this.shuffleBtn = this.createShuffleButton();
     this.revealBtn = this.createRevealButton();
     this.targetBtn = this.createTargetButton();
@@ -101,7 +103,14 @@ export class GameUI {
     mainMenuBtn.textContent = '🏠 Main Menu';
     mainMenuBtn.className = 'block w-full text-left px-3 py-2 text-sm text-hw-text-primary hover:bg-hw-surface-secondary rounded-lg transition-colors mb-2';
     panel.appendChild(mainMenuBtn);
-    
+
+    // Level Explorer button
+    const exploreBtn = document.createElement('button');
+    exploreBtn.id = 'explore-levels';
+    exploreBtn.textContent = '🧭 Explore Levels';
+    exploreBtn.className = 'block w-full text-left px-3 py-2 text-sm text-hw-text-primary hover:bg-hw-surface-secondary rounded-lg transition-colors mb-2';
+    panel.appendChild(exploreBtn);
+
     // Divider
     const divider = document.createElement('div');
     divider.className = 'border-t border-hw-surface-tertiary/20 my-2';
@@ -131,7 +140,17 @@ export class GameUI {
     
     return panel;
   }
-  
+
+  private createExploreButton(): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.id = 'hw-explore-btn';
+    btn.className = 'absolute right-1 top-12 w-8 h-8 rounded-full text-hw-text-primary backdrop-blur-md border transition-all duration-base flex items-center justify-center pointer-events-auto';
+    btn.style.cssText = 'background: rgba(42, 52, 70, 0.7); border-color: rgba(59, 71, 96, 0.3);';
+    btn.innerHTML = '<span style="font-size: 14px;">🧭</span>';
+    btn.title = 'Explore Levels';
+    return btn;
+  }
+
   private createShuffleButton(): HTMLButtonElement {
     const btn = document.createElement('button');
     btn.id = 'hw-shuffle-btn';
@@ -273,7 +292,18 @@ export class GameUI {
       this.shareBtn.style.background = 'rgba(42, 52, 70, 0.8)';
       this.shareBtn.style.transform = 'scale(1)';
     });
-    
+
+    // Explore button hover effect
+    this.exploreBtn.addEventListener('mouseenter', () => {
+      this.exploreBtn.style.background = 'rgba(59, 71, 96, 0.85)';
+      this.exploreBtn.style.transform = 'scale(1.05)';
+    });
+
+    this.exploreBtn.addEventListener('mouseleave', () => {
+      this.exploreBtn.style.background = 'rgba(42, 52, 70, 0.7)';
+      this.exploreBtn.style.transform = 'scale(1)';
+    });
+
     // Close menu when clicking outside
     document.addEventListener('click', (e) => {
       if (!this.settingsBtn.contains(e.target as Node) && 
@@ -289,6 +319,7 @@ export class GameUI {
     this.container.appendChild(this.coinEl);
     this.container.appendChild(this.settingsBtn);
     this.container.appendChild(this.menuPanel);
+    this.container.appendChild(this.exploreBtn);
     this.container.appendChild(this.shuffleBtn);
     this.container.appendChild(this.revealBtn);
     this.container.appendChild(this.targetBtn);
@@ -367,6 +398,19 @@ export class GameUI {
   public onMainMenu(callback: () => void): void {
     const mainMenuBtn = this.menuPanel.querySelector('#main-menu');
     mainMenuBtn?.addEventListener('click', () => {
+      callback();
+      this.menuPanel.classList.add('hidden');
+    });
+  }
+
+  public onExploreLevels(callback: () => void): void {
+    this.exploreBtn.addEventListener('click', () => {
+      callback();
+      this.menuPanel.classList.add('hidden');
+    });
+
+    const exploreMenuBtn = this.menuPanel.querySelector('#explore-levels');
+    exploreMenuBtn?.addEventListener('click', () => {
       callback();
       this.menuPanel.classList.add('hidden');
     });

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -302,7 +302,11 @@ class App {
         this.handleShare();
       }
     });
-    
+
+    this.gameUI.onExploreLevels(async () => {
+      await this.openLevelExplorer();
+    });
+
     this.gameUI.onHowToPlay(() => {
       this.showHowTo();
     });
@@ -793,7 +797,22 @@ class App {
       }
     }
   }
-  
+
+  private async openLevelExplorer(): Promise<void> {
+    try {
+      const { LevelManager } = await import('./features/LevelManager');
+      const manager = new LevelManager();
+      const result = await manager.show();
+
+      if (result?.action === 'play' && result.levelId) {
+        await this.playUserLevel(result.levelId);
+      }
+    } catch (error) {
+      console.error('Failed to open level explorer:', error);
+      this.showToast('Failed to open level explorer', 'error');
+    }
+  }
+
   private formatRelativeTime(dateString: string): string {
     const date = new Date(dateString);
     const now = new Date();

--- a/src/server/routes/userLevels.ts
+++ b/src/server/routes/userLevels.ts
@@ -206,18 +206,15 @@ router.post('/api/user-levels', async (req: Request, res: Response) => {
 router.get('/api/user-levels/mine', async (_req: Request, res: Response) => {
   try {
     const username = await reddit.getCurrentUsername();
-    if (!username) {
-      // Return empty list for anonymous users instead of error
-      return res.json({ levels: [] });
-    }
-    
-    const key = getUserKey(username);
+    const effectiveUsername = username || 'anonymous';
+
+    const key = getUserKey(effectiveUsername);
     console.log('Fetching user levels for key:', key);
     
     // Get the JSON array of level IDs
     const idsJson = await redis.get(key);
     if (!idsJson) {
-      console.log('No levels found for user:', username);
+      console.log('No levels found for user:', effectiveUsername);
       return res.json({ levels: [] });
     }
     


### PR DESCRIPTION
## Summary
- add a dedicated Explore Levels control to the in-game HUD and settings menu
- expose a new GameUI callback so the app can launch the level manager while playing
- return anonymous users' saved levels from the /api/user-levels/mine endpoint so freshly created levels appear

## Testing
- `npm test` *(fails: existing determinism, word placement, and game state specs already failing in repo)*
- `npm run type-check` *(fails: numerous pre-existing TypeScript errors in web-view and server sources)*

------
https://chatgpt.com/codex/tasks/task_b_68cfd13658948327b8761a9791c76a96