### PR TITLE
Add daily challenge splash experience

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -9,6 +9,9 @@
       }
     }
   },
+  "media": {
+    "dir": "assets"
+  },
   "server": {
     "dir": "dist/server",
     "entry": "index.cjs"

--- a/src/client/public/assets/daily-challenge-splash.svg
+++ b/src/client/public/assets/daily-challenge-splash.svg
@@ -1,0 +1,34 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">HexaWord Daily Challenge Splash Background</title>
+  <desc id="desc">Gradient background with subtle hexagon grid and focal highlight for the HexaWord daily challenge splash screen.</desc>
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E1A47" />
+      <stop offset="50%" stop-color="#2B3A8A" />
+      <stop offset="100%" stop-color="#1A5C73" />
+    </linearGradient>
+    <radialGradient id="spotlight" cx="0.5" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.35)" />
+      <stop offset="60%" stop-color="rgba(255, 255, 255, 0.05)" />
+      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
+    </radialGradient>
+    <pattern id="hexPattern" width="60" height="52" patternUnits="userSpaceOnUse" patternTransform="scale(1.2)">
+      <path d="M30 0l26 15v30l-26 15-26-15V15z" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="2" />
+    </pattern>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="40" />
+    </filter>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bgGradient)" />
+  <rect width="1600" height="900" fill="url(#hexPattern)" opacity="0.4" />
+  <circle cx="1150" cy="260" r="420" fill="url(#spotlight)" />
+  <g opacity="0.35" filter="url(#softGlow)">
+    <circle cx="300" cy="780" r="180" fill="#4CE0B3" />
+    <circle cx="1340" cy="720" r="220" fill="#FFB347" />
+  </g>
+  <g opacity="0.65">
+    <path d="M900 140l90 52v105l-90 52-90-52V192z" fill="rgba(255,255,255,0.08)" />
+    <path d="M1100 360l90 52v105l-90 52-90-52V412z" fill="rgba(255,255,255,0.08)" />
+    <path d="M1260 160l90 52v105l-90 52-90-52V212z" fill="rgba(76, 224, 179, 0.15)" />
+  </g>
+</svg>

--- a/src/client/public/assets/hexaword-icon.svg
+++ b/src/client/public/assets/hexaword-icon.svg
@@ -1,0 +1,26 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">HexaWord App Icon</title>
+  <desc id="desc">Hexagonal badge with stylized H glyph representing the HexaWord brand.</desc>
+  <defs>
+    <linearGradient id="iconGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4CE0B3" />
+      <stop offset="100%" stop-color="#2B75FF" />
+    </linearGradient>
+    <linearGradient id="glyphGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#E1ECFF" stop-opacity="0.95" />
+    </linearGradient>
+    <filter id="dropShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="20" stdDeviation="30" flood-color="#0B1D40" flood-opacity="0.45" />
+    </filter>
+  </defs>
+  <g filter="url(#dropShadow)">
+    <path d="M256 32l192 112v224L256 480 64 368V144z" fill="url(#iconGradient)" />
+  </g>
+  <path d="M196 148h120l64 110-64 110H196l-64-110z" fill="rgba(11, 29, 64, 0.25)" />
+  <path d="M216 168h80l48 90-48 90h-80l-48-90z" fill="url(#glyphGradient)" />
+  <rect x="244" y="188" width="24" height="136" rx="12" fill="#142850" />
+  <rect x="244" y="188" width="24" height="136" rx="12" fill="rgba(20, 40, 80, 0.35)" />
+  <rect x="244" y="248" width="84" height="24" rx="12" fill="#142850" />
+  <rect x="184" y="248" width="84" height="24" rx="12" fill="#142850" />
+</svg>

--- a/src/server/core/post.ts
+++ b/src/server/core/post.ts
@@ -1,4 +1,35 @@
 import { context, reddit } from "@devvit/web/server";
+import { calculateCycleDay, getChallengeForDay } from "../data/dailyChallenges";
+
+const formatDayTypeHeading = (dayType: string): string => {
+  const formatted = dayType
+    .split(" ")
+    .map((segment) =>
+      segment
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join("-")
+    )
+    .join(" ");
+  return `${formatted} Daily Challenge`;
+};
+
+const extractLetterSet = (words: string[]): string => {
+  const seen = new Set<string>();
+  const orderedLetters: string[] = [];
+
+  for (const word of words) {
+    for (const char of word.toUpperCase()) {
+      if (!/[A-Z]/.test(char) || seen.has(char)) {
+        continue;
+      }
+      seen.add(char);
+      orderedLetters.push(char);
+    }
+  }
+
+  return orderedLetters.join(" · ");
+};
 
 export const createPost = async () => {
   const { subredditName } = context;
@@ -6,11 +37,34 @@ export const createPost = async () => {
     throw new Error("subredditName is required");
   }
 
+  const today = new Date();
+  const cycleDay = calculateCycleDay(today);
+  const challenge = getChallengeForDay(cycleDay);
+
+  const heading = formatDayTypeHeading(challenge.dayType);
+  const letterPrompt = extractLetterSet(challenge.words);
+
   return await reddit.submitCustomPost({
     splash: {
-      appDisplayName: "hexaword",
+      appDisplayName: "HexaWord",
+      heading,
+      description: `Today's clue: ${challenge.clue}. Use these letters to uncover ${challenge.words.length} themed words and keep your streak alive: ${letterPrompt}. Share your daily run, conquer curated levels, and compare progress with friends.`,
+      buttonLabel: "Play the Daily Challenge",
+      backgroundUri: "/daily-challenge-splash.svg",
+      appIconUri: "/hexaword-icon.svg",
+      entryUri: "index.html",
     },
     subredditName: subredditName,
     title: "hexaword",
+    postData: {
+      splashMeta: {
+        cycleDay,
+        clue: challenge.clue,
+        difficulty: challenge.difficulty,
+        dayType: challenge.dayType,
+        letters: letterPrompt,
+        wordCount: challenge.words.length,
+      },
+    },
   });
 };


### PR DESCRIPTION
## Summary
- configure the Devvit splash screen to highlight the current daily challenge clue, letters, and calls-to-action
- bundle branded splash background and icon assets and expose them via the media configuration
- persist splash metadata with the post for future use

## Testing
- `npm test` *(fails: existing determinism, placement, and scoring assertions in vitest suite)*

------
https://chatgpt.com/codex/tasks/task_b_68cfd6d11bc88327b29b2e67d4ab492f