### PR TITLE
fix: configure splash screen branding

### DIFF
--- a/src/server/core/post.ts
+++ b/src/server/core/post.ts
@@ -41,17 +41,18 @@ export const createPost = async () => {
   const cycleDay = calculateCycleDay(today);
   const challenge = getChallengeForDay(cycleDay);
 
-  const heading = formatDayTypeHeading(challenge.dayType);
+  const heading = `${formatDayTypeHeading(challenge.dayType)} · Day ${cycleDay}`;
   const letterPrompt = extractLetterSet(challenge.words);
+  const buttonLabel = challenge.dayType === "supreme" ? "Begin the Supreme Run" : "Play Today's Challenge";
 
   return await reddit.submitCustomPost({
     splash: {
       appDisplayName: "HexaWord",
       heading,
-      description: `${challenge.clue} - Find ${challenge.words.length} words`,
-      buttonLabel: "Play",
-      backgroundUri: "splash-background.svg",
-      appIconUri: "hexaword-icon.svg",
+      description: `${challenge.clue} · Letters: ${letterPrompt}`,
+      buttonLabel,
+      backgroundUri: "/daily-challenge-splash.svg",
+      appIconUri: "/hexaword-icon.svg",
       entryUri: "index.html",
     },
     subredditName: subredditName,
@@ -59,6 +60,8 @@ export const createPost = async () => {
     postData: {
       cycleDay,
       clue: challenge.clue,
+      letters: challenge.words,
+      heading,
     },
   });
 };


### PR DESCRIPTION
## Summary
- enrich the splash metadata with a daily heading, clue details, and letter set context
- point the splash art and icon to bundled assets for a branded presentation
- expose challenge metadata in post data for clients that surface shared levels

## Testing
- `npm test` *(fails: existing vitest suites currently red in main branch)*

------
https://chatgpt.com/codex/tasks/task_b_68cfff7c330c8327acebe2f32a9bf9c3