### PR TITLE
Add splash gradient background and glass panel

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -19,24 +19,34 @@
         width: 100%;
         height: 100%;
         overflow: hidden;
-        background-color: var(--hw-bg-primary);
+        background-color: var(--hw-bg-primary, #141511);
         transition: background-color var(--hw-transition-slow);
       }
-      
+
       body {
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        background: var(--hw-bg-primary);
+        background-color: #141511;
+        background-image:
+          radial-gradient(at 47% 33%, hsl(212.37, 72%, 59%) 0, transparent 59%),
+          radial-gradient(at 82% 65%, hsl(166.53, 72%, 60%) 0, transparent 55%);
+        background-repeat: no-repeat;
+        background-size: cover;
         color: var(--hw-text-primary);
         font-family: var(--hw-font-display);
       }
-      
+
+      .card {
+        backdrop-filter: blur(16px) saturate(180%);
+        -webkit-backdrop-filter: blur(16px) saturate(180%);
+        background-color: rgba(17, 25, 40, 0.75);
+        border-radius: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.125);
+      }
+
       #hex-grid-container {
-        background: var(--hw-bg-primary);
-        border: none;
-        box-shadow: none;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -68,7 +78,7 @@
     </style>
   </head>
   <body>
-    <div id="hex-grid-container">
+    <div id="hex-grid-container" class="card">
       <!-- Canvas will be inserted here -->
     </div>
     <script type="module" src="main.ts"></script>

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -119,11 +119,10 @@ class App {
       // Update top-level backgrounds to match theme
       document.documentElement.style.setProperty('background-color', scheme.background, 'important');
       document.body.style.setProperty('background-color', scheme.background, 'important');
-      document.body.style.setProperty('background', scheme.background, 'important');
       const container = document.getElementById('hex-grid-container');
       if (container) {
-        (container as HTMLElement).style.setProperty('background-color', scheme.background, 'important');
-        (container as HTMLElement).style.setProperty('background', scheme.background, 'important');
+        (container as HTMLElement).style.removeProperty('background');
+        (container as HTMLElement).style.removeProperty('background-color');
       }
       
       // Apply clue-like effects to the HEXA WORDS title
@@ -133,7 +132,6 @@ class App {
       const bg = '#0F1115';
       document.documentElement.style.setProperty('background-color', bg, 'important');
       document.body.style.setProperty('background-color', bg, 'important');
-      document.body.style.setProperty('background', bg, 'important');
     }
   }
   


### PR DESCRIPTION
## Summary
- add a radial gradient background and reusable glassmorphism card styling to the splash layout
- stop runtime palette changes from overwriting the new splash card styling

## Testing
- `npm test` *(fails: existing determinism and word placement expectations are unmet in the current baseline)*

------
https://chatgpt.com/codex/tasks/task_b_68d001178630832782fa6bc46b8910f1