### PR TITLE
Default user level status and backfill

### DIFF
--- a/src/server/routes/userLevels.ts
+++ b/src/server/routes/userLevels.ts
@@ -31,6 +31,17 @@ type UserLevelRecord = {
   sharedBy?: string[];
 };
 
+type StoredUserLevelRecord = Omit<UserLevelRecord, 'status'> & {
+  status?: UserLevelRecord['status'];
+};
+
+function normalizeLevelRecord(level: StoredUserLevelRecord): UserLevelRecord {
+  return {
+    ...level,
+    status: level.status ?? 'active'
+  };
+}
+
 const router = express.Router();
 
 // ------- Validation Schemas -------
@@ -209,6 +220,61 @@ router.post('/api/user-levels', async (req: Request, res: Response) => {
   }
 });
 
+// Migration helper to backfill missing status properties on stored levels
+router.post('/api/user-levels/migrate-status', async (_req: Request, res: Response) => {
+  try {
+    const globalIndexKey = 'hw:ulevels:global:index';
+    const globalIdsJson = await redis.get(globalIndexKey);
+
+    if (!globalIdsJson) {
+      return res.json({
+        success: true,
+        message: 'No global index found',
+        total: 0,
+        updated: 0
+      });
+    }
+
+    const globalIds: string[] = JSON.parse(globalIdsJson);
+    let processed = 0;
+    let updated = 0;
+
+    for (const id of globalIds) {
+      const levelKey = `hw:ulevel:${id}`;
+      const raw = await redis.get(levelKey);
+      if (!raw) continue;
+
+      try {
+        const storedLevel = JSON.parse(raw) as StoredUserLevelRecord;
+        processed += 1;
+        if (storedLevel.status == null) {
+          const normalized = normalizeLevelRecord(storedLevel);
+          await redis.set(levelKey, JSON.stringify(normalized));
+          updated += 1;
+        }
+      } catch (parseErr) {
+        console.error(`Failed to migrate level ${id}:`, parseErr);
+      }
+    }
+
+    return res.json({
+      success: true,
+      message: 'Migration complete',
+      total: processed,
+      updated
+    });
+  } catch (err) {
+    console.error('Status migration failed:', err);
+    return res.status(500).json({
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'Failed to migrate level statuses',
+        details: err.message
+      }
+    });
+  }
+});
+
 // Explore levels - search and filter functionality
 router.get('/api/user-levels/explore', async (req: Request, res: Response) => {
   try {
@@ -242,7 +308,7 @@ router.get('/api/user-levels/explore', async (req: Request, res: Response) => {
       try {
         const raw = await redis.get(`hw:ulevel:${id}`);
         if (raw) {
-          const level = JSON.parse(raw);
+          const level = normalizeLevelRecord(JSON.parse(raw));
           // Only include public/active levels
           if (level.status === 'active') {
             allLevels.push(level);
@@ -339,7 +405,7 @@ router.get('/api/user-levels/mine', async (_req: Request, res: Response) => {
       try {
         const raw = await redis.get(`hw:ulevel:${id}`);
         if (raw) {
-          const parsed = JSON.parse(raw);
+          const parsed = normalizeLevelRecord(JSON.parse(raw));
           levels.push(parsed);
         }
       } catch (parseErr) {
@@ -367,7 +433,7 @@ router.get('/api/user-levels/:id', async (req: Request, res: Response) => {
       return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
     }
     
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Increment play count when level is accessed
     level.playCount = (level.playCount || 0) + 1;
@@ -393,7 +459,7 @@ router.post('/api/user-levels/:id/share', async (req: Request, res: Response) =>
       return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
     }
     
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Increment share count
     level.shares = (level.shares || 0) + 1;
@@ -426,7 +492,7 @@ router.delete('/api/user-levels/:id', async (req: Request, res: Response) => {
       return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
     }
     
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Check if user owns this level
     if (level.author !== username) {
@@ -477,7 +543,7 @@ router.post('/api/user-levels/:id/vote', async (req: Request, res: Response) => 
       return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
     }
     
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Initialize arrays if not present
     if (!level.upvotedBy) level.upvotedBy = [];
@@ -565,7 +631,7 @@ router.post('/api/user-levels/:id/share', async (req: Request, res: Response) =>
       return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
     }
     
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Initialize array if not present
     if (!level.sharedBy) level.sharedBy = [];
@@ -601,7 +667,7 @@ router.get('/api/user-levels/:id/init', async (req: Request, res: Response) => {
     const levelKey = `hw:ulevel:${id}`;
     const raw = await redis.get(levelKey);
     if (!raw) return res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Level not found' } });
-    const level: UserLevelRecord = JSON.parse(raw);
+    const level = normalizeLevelRecord(JSON.parse(raw));
     
     // Get username first
     const username = (await reddit.getCurrentUsername()) || 'anonymous';

--- a/src/tests/userLevelsExplore.test.ts
+++ b/src/tests/userLevelsExplore.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@devvit/web/server', () => {
+  const store = new Map<string, string>();
+
+  const redisMock = {
+    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key)! : null)),
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    del: vi.fn(async (key: string) => {
+      const existed = store.delete(key);
+      return existed ? 1 : 0;
+    }),
+    zAdd: vi.fn(),
+    __reset: () => store.clear()
+  };
+
+  return {
+    reddit: {
+      getCurrentUsername: vi.fn(async () => 'test-user')
+    },
+    redis: redisMock,
+    context: {}
+  };
+});
+
+import router from '../server/routes/userLevels';
+import { redis } from '@devvit/web/server';
+
+type RouterLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: (req: unknown, res: unknown, next: () => void) => unknown }>;
+  };
+};
+
+function getRouteHandler(path: string, method: string) {
+  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
+  for (const layer of stack) {
+    if (layer.route?.path === path && layer.route.methods?.[method.toLowerCase()]) {
+      return layer.route.stack[0].handle;
+    }
+  }
+  throw new Error(`Route handler not found for ${method.toUpperCase()} ${path}`);
+}
+
+describe('user level explore route', () => {
+  const exploreHandler = getRouteHandler('/api/user-levels/explore', 'get');
+
+  beforeEach(async () => {
+    (redis as unknown as { __reset: () => void }).__reset();
+    await redis.set('hw:ulevels:global:index', JSON.stringify([]));
+  });
+
+  it('treats missing status as active when returning explore results', async () => {
+    const levelId = 'ul_test_level';
+    const levelData = {
+      id: levelId,
+      author: 'alice',
+      clue: 'Sample clue',
+      words: ['alpha', 'beta'],
+      seed: 'seed',
+      generatorVersion: '1',
+      createdAt: new Date().toISOString(),
+      visibility: 'public'
+    };
+
+    await redis.set('hw:ulevels:global:index', JSON.stringify([levelId]));
+    await redis.set(`hw:ulevel:${levelId}`, JSON.stringify(levelData));
+
+    const req = { query: {} };
+    const json = vi.fn((payload) => payload);
+    const res = { json };
+
+    await exploreHandler(req, res, () => {
+      throw new Error('next should not be called');
+    });
+
+    expect(json).toHaveBeenCalledTimes(1);
+    const payload = json.mock.calls[0][0];
+
+    expect(payload.total).toBe(1);
+    expect(payload.levels).toHaveLength(1);
+    expect(payload.levels[0].status).toBe('active');
+    expect(payload.levels[0].id).toBe(levelId);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize stored user level records so missing statuses default to `active` when routes load them
- add a migration endpoint to backfill persisted levels that are missing a status
- cover the explore endpoint with a unit test to ensure levels without a stored status are returned

## Testing
- npx vitest run src/tests/determinism.test.ts *(fails: existing expectation that different seeds produce different puzzles)*
- npx vitest run src/tests/userLevelsExplore.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d025912b548327953783be07a19fd4