### PR TITLE
Fix shared level deep-link flow

### DIFF
--- a/src/client/utils/levelLinks.ts
+++ b/src/client/utils/levelLinks.ts
@@ -1,0 +1,35 @@
+/**
+ * Extracts the level query parameter from a search string.
+ */
+export function getLevelQuery(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const value = params.get('level');
+  return value && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Determines if the provided level identifier represents a user-created level.
+ * User level identifiers are non-empty and contain non-numeric characters.
+ */
+export function isUserLevelId(levelId: string | null | undefined): levelId is string {
+  if (!levelId) {
+    return false;
+  }
+
+  return !/^\d+$/.test(levelId);
+}
+
+/**
+ * Checks if the provided search string contains a level query parameter.
+ */
+export function hasLevelQuery(search: string): boolean {
+  return getLevelQuery(search) !== null;
+}
+
+/**
+ * Returns true when the search string corresponds to a user level deep link.
+ */
+export function shouldAutoLaunchUserLevel(search: string): boolean {
+  const levelId = getLevelQuery(search);
+  return isUserLevelId(levelId);
+}

--- a/src/tests/levelLinks.test.ts
+++ b/src/tests/levelLinks.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getLevelQuery, hasLevelQuery, isUserLevelId, shouldAutoLaunchUserLevel } from '../client/utils/levelLinks';
+
+describe('level link helpers', () => {
+  it('extracts level query values when present', () => {
+    expect(getLevelQuery('?level=ul_abc')).toBe('ul_abc');
+    expect(getLevelQuery('?foo=bar&level=123')).toBe('123');
+    expect(getLevelQuery('?level=')).toBeNull();
+    expect(getLevelQuery('')).toBeNull();
+  });
+
+  it('detects when a search string contains a level parameter', () => {
+    expect(hasLevelQuery('?level=ul_test')).toBe(true);
+    expect(hasLevelQuery('?foo=bar')).toBe(false);
+    expect(hasLevelQuery('')).toBe(false);
+  });
+
+  it('identifies user-level identifiers correctly', () => {
+    expect(isUserLevelId('ul_123abc')).toBe(true);
+    expect(isUserLevelId('123')).toBe(false);
+    expect(isUserLevelId('')).toBe(false);
+    expect(isUserLevelId(null)).toBe(false);
+  });
+
+  it('determines when to auto-launch user levels', () => {
+    expect(shouldAutoLaunchUserLevel('?level=ul_test')).toBe(true);
+    expect(shouldAutoLaunchUserLevel('?level=42')).toBe(false);
+    expect(shouldAutoLaunchUserLevel('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- skip showing the main menu when a shared level deep link successfully launches and guard splash handling to ignore numeric level codes
- ensure shared level play actions only hide the menu and dismiss the splash after the level loads successfully
- add reusable URL helpers for level links together with unit tests covering the parsing logic

## Testing
- npm run type-check *(fails: existing TypeScript errors in shared modules referencing process/env and undefined fields)*
- npm test -- --run *(fails: existing TypeScript errors and pre-existing failing suites)*

------
https://chatgpt.com/codex/tasks/task_b_68d11414e5e483279728b899c50bc807